### PR TITLE
Fail installation when failed to download binary

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -16,7 +16,7 @@ install_yq() {
   mkdir -p "${bin_install_path}"
 
   echo "Downloading yq from ${download_url} to ${binary_path}"
-  curl -L "${download_url}" -o "${binary_path}"
+  curl -fL "${download_url}" -o "${binary_path}"
   chmod +x "${binary_path}"
 }
 


### PR DESCRIPTION
Current `install` implementation will not fail even if user tries to download non-existing version, for example: 

```sh
➜  /Users/hoon asdf install yq 4.5.0
Creating bin directory
Downloading yq from https://github.com/mikefarah/yq/releases/download/4.5.0/yq_darwin_amd64 to /Users/hoon/.asdf/installs/yq/4.5.0/bin/yq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9  100     9    0     0     28      0 --:--:-- --:--:-- --:--:--    28
➜  /Users/hoon asdf global yq 4.5.0
➜  /Users/hoon yq
/Users/hoon/.asdf/installs/yq/4.5.0/bin/yq: line 1: Not: command not found
➜  /Users/hoon cat /Users/hoon/.asdf/installs/yq/4.5.0/bin/yq
Not Found%
```

## Changes

Set fail (`-f`) option when downloading `yq` binary from GitHub