### PR TITLE
Fix broken test

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
-        yq: [2.4.3]
+        yq: [2.4.1, 3.4.1, v4.5.0]
 
     runs-on: ${{ matrix.os }}
 
@@ -16,5 +16,6 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v1.0.0
         with:
           command: "yq --version"
+          version: ${{ matrix.yq }}
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1.0.0
+        uses: asdf-vm/actions/plugin-test@v1.1.0
         with:
           command: "yq --version"
           version: ${{ matrix.yq }}


### PR DESCRIPTION
## Background

My previous PR (#2) breaks [checks](https://github.com/sudermanjr/asdf-yq/runs/1835381830) 😢, and it seems disabled `set-env` command is breaking checks.

(Reference - [GitHub Actions: Deprecating set-env and add-path commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))

## Changes

- Bump `plugin-test` action version to 1.1.0 ([asdf-vm/actions@v1.1.0](https://github.com/asdf-vm/actions/releases/tag/v1.1.0) which removes `set-env` command usage
- Explicitly set yq version in workflow
  - Test 3 major versions (v2, v3, v4) using matrix