### PR TITLE
Show all github releases when listing versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -2,19 +2,15 @@
 
 set -euo pipefail
 
-release_path=https://api.github.com/repos/mikefarah/yq/releases
-cmd='curl --fail --silent'
-if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-  cmd="${cmd} -H 'Authorization: token ${GITHUB_API_TOKEN}'"
-fi
-cmd="$cmd $release_path"
-
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-eval "${cmd} '${release_path}'" |
-  jq '.[] | select(.prerelease == false) | .tag_name | sub("v"; "")' -r |
-  tac |
-  xargs echo
+list_all_versions() {
+  git ls-remote --tags --refs https://github.com/mikefarah/yq.git |
+  sed -E -n 's,.*refs/tags/(.*),\1,p' |
+  sed -E -n 's,^v?([0-9](\.[0-9])*)$,\1,p'
+}
+
+list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
The default page size for github API is 30, but currently that only
fits the releases with the 4.x branch.

Instead of having to use the github API to fetch releases, just utilize
git and check all tags in the repo and filter out undesired ones.

Git is already a requirement for asdf so it's fine to use it.

Prior work can be found in the kubectl plugin:
asdf-community/asdf-kubectl#15