### PR TITLE
Fix duplicate versions

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -13,4 +13,4 @@ list_all_versions() {
   sed -E -n 's,^v?([0-9](\.[0-9])*)$,\1,p'
 }
 
-list_all_versions | sort_versions | xargs echo
+list_all_versions | sort_versions | uniq | xargs echo


### PR DESCRIPTION
The list-all call returns duplicate versions because the yq
repo has multiple version tags for the same version.
(one with a v prefix and one without)