### PR TITLE
Fix discovery of versions with multiple digits in version segment

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -10,7 +10,7 @@ function sort_versions() {
 list_all_versions() {
   git ls-remote --tags --refs https://github.com/mikefarah/yq.git |
   sed -E -n 's,.*refs/tags/(.*),\1,p' |
-  sed -E -n 's,^v?([0-9](\.[0-9])*)$,\1,p'
+  sed -E -n 's,^v?([0-9]+(\.[0-9]+)*)$,\1,p'
 }
 
 list_all_versions | sort_versions | uniq | xargs echo

--- a/bin/list-all
+++ b/bin/list-all
@@ -2,15 +2,10 @@
 
 set -euo pipefail
 
-function sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
 list_all_versions() {
   git ls-remote --tags --refs https://github.com/mikefarah/yq.git |
   sed -E -n 's,.*refs/tags/(.*),\1,p' |
   sed -E -n 's,^v?([0-9]+(\.[0-9]+)*)$,\1,p'
 }
 
-list_all_versions | sort_versions | uniq | xargs echo
+list_all_versions | uniq | sort -V


### PR DESCRIPTION
- Fix discovery of versions with multiple digits in version segment
Later versions have double digit minor segments, e.g. `4.16.1`, which do not show up in `list-all` due to the regex not matching multiple digit segments.

- Use built-in sort versioning
Remove the sort function in favour of using sort's built-in version sorting.