### PR TITLE
Revert to amd64 for versions without arm64 build

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -44,12 +44,23 @@ get_download_url() {
   local filename
   local major
   local minor
-  filename="$(get_filename "${platform}")"
+  local patch
+
   major="$(echo "${version}" | cut -f1 -d.)"
   minor="$(echo "${version}" | cut -f2 -d.)"
+  patch="$(echo "${version}" | cut -f3 -d.)"
+
+  if [[ "${platform}" == "darwin_arm64" && ("${major}" -lt 4 || ("${major}" -eq 4 && "${minor}" -lt 9) || ("${major}" -eq 4 && "${minor}" -eq 9 && "${patch}" -lt 6)) ]] ; then
+    # arm64 builds are introduced from 4.9.6 onwards
+    platform="darwin_amd64"
+  fi
+
+  filename="$(get_filename "${platform}")"
+  
   if [[ "${major}" -gt 4 || ("${major}" -eq 4 && "${minor}" -gt 0) ]] ; then
     version="v${version}"
   fi
+
   echo "https://github.com/mikefarah/yq/releases/download/${version}/${filename}"
 }
 


### PR DESCRIPTION
Fix for #12.

Output for 4.9.5:
```zsh
% asdf install yq 4.9.5  
Creating bin directory
Downloading yq from https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_darwin_amd64 to /Users/sander.ginn/.asdf/installs/yq/4.9.5/bin/yq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   652  100   652    0     0   2582      0 --:--:-- --:--:-- --:--:--  2650
100 6427k  100 6427k    0     0  3181k      0  0:00:02  0:00:02 --:--:-- 5551k
```

Output for 4.9.6:
```zsh
 % asdf install yq 4.9.6
Creating bin directory
Downloading yq from https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_darwin_arm64 to /Users/sander.ginn/.asdf/installs/yq/4.9.6/bin/yq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   652  100   652    0     0   1815      0 --:--:-- --:--:-- --:--:--  1841
100 6338k  100 6338k    0     0  4261k      0  0:00:01  0:00:01 --:--:-- 7462k
```